### PR TITLE
chore: migrate readme stats to GitHub Actions

### DIFF
--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -1,0 +1,64 @@
+name: Update README Stats
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  generate-and-commit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Allows the action to push changes
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Generate General Stats
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: stats
+          token: ${{ secrets.GITHUB_TOKEN }}
+          options: |
+            {
+              "username": "notxart",
+              "hide": "stars,contribs",
+              "show_icons": true,
+              "theme": "radical",
+              "title_color": "ff3068",
+              "icon_color": "fe428e",
+              "border_color": "f8d847",
+              "border_radius": 10
+            }
+          path: "profile/stats.svg"
+
+      - name: Generate Top Languages
+        uses: readme-tools/github-readme-stats-action@v1
+        with:
+          card: top-langs
+          token: ${{ secrets.GITHUB_TOKEN }}
+          options: |
+            {
+              "username": "notxart",
+              "langs_count": 4,
+              "layout": "compact",
+              "hide_title": true,
+              "theme": "radical",
+              "border_color": "f8d847",
+              "border_radius": 10
+            }
+          path: "profile/top-langs.svg"
+
+      - name: Commit and Push Changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Stage the generated files
+          git add profile/*.svg
+          # Commit only if there are changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update profile stats images [skip ci]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD033 -->
 <h1 align="center"> 𝐻𝑖 𝑡ℎ𝑒𝑟𝑒, 𝐼 𝑎𝑚 𝑇𝑟𝑎𝑥𝑡𝑜𝑛 <img alt="Hi" width="34" src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" /></h1>
 
 <!-- Marquee stuff -->
@@ -23,9 +24,9 @@
   <tr>
     <td width="59%">
       <a href="https://github.com/notxart">
-        <img alt="GitHub Stats" width="100%" src="https://github-readme-stats.vercel.app/api?username=notxart&hide=stars,contribs&show_icons=true&theme=radical&title_color=ff3068?&icon_color=fe428e&border_color=f8d847&border_radius=10" />
+        <img alt="GitHub Stats" width="100%" src="./profile/stats.svg" />
         <img alt="GitHub Streak" width="100%" src="https://streak-stats.demolab.com?user=notxart&theme=radical&border_radius=10&mode=weekly&border=F8D847" />
-        <img alt="Most Used Languages" width="100%" src="https://github-readme-stats.vercel.app/api/top-langs/?username=notxart&langs_count=4&layout=compact&hide_title=true&theme=radical&border_color=f8d847&border_radius=10" />
+        <img alt="Most Used Languages" width="100%" src="./profile/top-langs.svg" />
       </a>
     </td>
     <td width="41%">


### PR DESCRIPTION
### Summary
Migrates the profile stats generation from the unstable Vercel instance to a self-hosted GitHub Actions workflow.

### Changes
- Added `.github/workflows/update-stats.yml` to generate stats daily.
- Updated `README.md` to use local SVG paths (`./profile/`) instead of external URLs.